### PR TITLE
Fix UI component import paths to use PascalCase

### DIFF
--- a/app/relations/page.tsx
+++ b/app/relations/page.tsx
@@ -2,11 +2,11 @@
 
 import { useState } from 'react'
 import { Network, Search, Plus, Eye, BarChart3 } from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/Button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
 import { Input } from '@/components/ui/input'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { Badge } from '@/components/ui/badge'
+import { Badge } from '@/components/ui/Badge'
 import {
   useNotes,
   useRelationsStats,

--- a/app/summaries/page.tsx
+++ b/app/summaries/page.tsx
@@ -2,9 +2,9 @@
 
 import { useState } from 'react'
 import { FileText, Brain, Clock, Zap, Plus, Download } from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/Button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
+import { Badge } from '@/components/ui/Badge'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import {
   useSummaryStats,

--- a/app/templates/page.tsx
+++ b/app/templates/page.tsx
@@ -1,10 +1,10 @@
 'use client'
 
 import { useState } from 'react'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card'
+import { Button } from '@/components/ui/Button'
 import { Input } from '@/components/ui/input'
-import { Badge } from '@/components/ui/badge'
+import { Badge } from '@/components/ui/Badge'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { FileText, Plus, Search, Star, Globe, User } from 'lucide-react'
 import { useTemplates, usePublicTemplates, useTemplateCategories, useCreateTemplate } from '@/hooks/use-templates'

--- a/app/voice-notes/page.tsx
+++ b/app/voice-notes/page.tsx
@@ -1,9 +1,9 @@
 'use client'
 
 import { useState, useRef } from 'react'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card'
+import { Button } from '@/components/ui/Button'
+import { Badge } from '@/components/ui/Badge'
 import { Input } from '@/components/ui/input'
 import { Mic, Upload, Play, Pause, Download, Trash2, Clock, FileAudio } from 'lucide-react'
 import { useVoiceNotes, useCreateVoiceNote } from '@/hooks/use-features'

--- a/components/categories/CategoryCreateDialog.tsx
+++ b/components/categories/CategoryCreateDialog.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Button } from '@/components/ui/button'
+import { Button } from '@/components/ui/Button'
 import {
   Dialog,
   DialogContent,
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Switch } from '@/components/ui/switch'
-import { Badge } from '@/components/ui/badge'
+import { Badge } from '@/components/ui/Badge'
 import { X } from 'lucide-react'
 import { type CreateCategoryDto } from '@/types'
 

--- a/components/categories/CategoryEditDialog.tsx
+++ b/components/categories/CategoryEditDialog.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Button } from '@/components/ui/button'
+import { Button } from '@/components/ui/Button'
 import {
   Dialog,
   DialogContent,
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
 import { Switch } from '@/components/ui/switch'
-import { Badge } from '@/components/ui/badge'
+import { Badge } from '@/components/ui/Badge'
 import { X } from 'lucide-react'
 import { type Category, type UpdateCategoryDto } from '@/types'
 

--- a/components/duplicates/DuplicateGroupCard.tsx
+++ b/components/duplicates/DuplicateGroupCard.tsx
@@ -1,6 +1,6 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
+import { Button } from '@/components/ui/Button'
+import { Badge } from '@/components/ui/Badge'
 import { Copy, Merge, Eye, AlertTriangle } from 'lucide-react'
 
 interface DuplicateGroup {

--- a/components/duplicates/DuplicateReportsList.tsx
+++ b/components/duplicates/DuplicateReportsList.tsx
@@ -1,6 +1,6 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
+import { Button } from '@/components/ui/Button'
+import { Badge } from '@/components/ui/Badge'
 import { FileText, Download, Calendar } from 'lucide-react'
 
 import { type DuplicateDetectionReport } from '@/types'

--- a/components/duplicates/DuplicateStatsCard.tsx
+++ b/components/duplicates/DuplicateStatsCard.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
 import { Copy, AlertTriangle, TrendingDown, Clock } from 'lucide-react'
 
 interface DuplicateStats {

--- a/components/duplicates/MergeDialog.tsx
+++ b/components/duplicates/MergeDialog.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Button } from '@/components/ui/button'
+import { Button } from '@/components/ui/Button'
 import {
   Dialog,
   DialogContent,
@@ -8,8 +8,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
-import { Card, CardContent } from '@/components/ui/card'
-import { Badge } from '@/components/ui/badge'
+import { Card, CardContent } from '@/components/ui/Card'
+import { Badge } from '@/components/ui/Badge'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { Label } from '@/components/ui/label'
 import { Merge, FileText, Calendar, AlertTriangle } from 'lucide-react'

--- a/components/relations/RelationsGraph.tsx
+++ b/components/relations/RelationsGraph.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
+import { Button } from '@/components/ui/Button'
+import { Badge } from '@/components/ui/Badge'
 import { Network, Maximize2, Download } from 'lucide-react'
 import { useNoteGraph } from '@/hooks'
 

--- a/components/relations/RelationsList.tsx
+++ b/components/relations/RelationsList.tsx
@@ -1,6 +1,6 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
+import { Button } from '@/components/ui/Button'
+import { Badge } from '@/components/ui/Badge'
 import { List, Eye, Link2, Trash2, Plus } from 'lucide-react'
 import { useStoredRelations, useRelatedNotes, useSaveRelation, useDeleteRelation } from '@/hooks'
 

--- a/components/relations/RelationsStats.tsx
+++ b/components/relations/RelationsStats.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
 import { Network, Link, TrendingUp, Users } from 'lucide-react'
 
 interface RelationsStatsData {

--- a/components/summaries/BatchGenerateDialog.tsx
+++ b/components/summaries/BatchGenerateDialog.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Button } from '@/components/ui/button'
+import { Button } from '@/components/ui/Button'
 import {
   Dialog,
   DialogContent,
@@ -10,8 +10,8 @@ import {
 } from '@/components/ui/dialog'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Label } from '@/components/ui/label'
-import { Badge } from '@/components/ui/badge'
-import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/Badge'
+import { Card, CardContent } from '@/components/ui/Card'
 import { FileText, Calendar } from 'lucide-react'
 import { type Note } from '@/types'
 

--- a/components/summaries/RecentSummariesList.tsx
+++ b/components/summaries/RecentSummariesList.tsx
@@ -1,6 +1,6 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
+import { Button } from '@/components/ui/Button'
+import { Badge } from '@/components/ui/Badge'
 import { FileText, Calendar, Eye, Edit } from 'lucide-react'
 import { useNotes } from '@/hooks'
 

--- a/components/summaries/SummaryStatsCard.tsx
+++ b/components/summaries/SummaryStatsCard.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
 import { FileText, Zap, Clock, TrendingUp } from 'lucide-react'
 
 interface SummaryStats {

--- a/components/summaries/SummaryTemplateCard.tsx
+++ b/components/summaries/SummaryTemplateCard.tsx
@@ -1,6 +1,6 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
-import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card'
+import { Button } from '@/components/ui/Button'
+import { Badge } from '@/components/ui/Badge'
 import { FileText, Zap } from 'lucide-react'
 
 interface SummaryTemplate {


### PR DESCRIPTION
## Purpose

The user identified 173 TypeScript errors across 61 files in their codebase. These errors were related to incorrect import paths for UI components that needed to follow PascalCase naming conventions instead of lowercase.

## Code changes

Updated import statements across multiple files to use PascalCase for UI components:

- Changed `@/components/ui/button` → `@/components/ui/Button`
- Changed `@/components/ui/card` → `@/components/ui/Card` 
- Changed `@/components/ui/badge` → `@/components/ui/Badge`

**Files modified:**
- `app/relations/page.tsx`
- `app/summaries/page.tsx` 
- `app/templates/page.tsx`
- `app/voice-notes/page.tsx`
- `components/categories/CategoryCreateDialog.tsx`
- `components/categories/CategoryEditDialog.tsx`
- `components/duplicates/` (4 files)
- `components/relations/` (3 files)
- `components/summaries/` (4 files)

Also added missing newlines at end of files where needed.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 56`

🔗 [Edit in Builder.io](https://builder.io/app/projects/3c18fd0b302046cc86d2d2fd6416aae0/zenith-studio)

👀 [Preview Link](https://3c18fd0b302046cc86d2d2fd6416aae0-zenith-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>3c18fd0b302046cc86d2d2fd6416aae0</projectId>-->
<!--<branchName>zenith-studio</branchName>-->